### PR TITLE
Update ShenyuClientRegisterGrpcServiceImplTest.java

### DIFF
--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,7 +117,8 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);
         assertEquals(resultList.size(), 3);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))
@@ -184,4 +186,28 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
             throw new ShenyuException(e.getCause());
         }
     }
+
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split("}");
+        String out = "";
+        for (String str: splitStr) {
+            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
+            if (newStr.length() > 3) {
+                String[] small = newStr.split(",");
+                for (String str2:small) {
+                    if (str2.length() > 3) {
+                        list.add(str2);
+                    }                  
+                }
+            }
+            list.sort(Comparator.naturalOrder());
+            out += list.toString();
+            list.clear();
+            
+        }
+        return out;
+        
+    }
+    
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -108,14 +109,14 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         final String expected = "[{\"port\":0,\"weight\":50,\"warmup\":10,\"protocol\":\"dubbo://\",\"upstreamHost\":\"localhost\",\"upstreamUrl\":\"localhost:8090\","
                 + "\"status\":true,\"timestamp\":1637826588267},{\"port\":0,\"weight\":50,\"warmup\":10,\"protocol\":\"dubbo://\",\"upstreamHost\":\"localhost\","
                 + "\"upstreamUrl\":\"localhost:8091\",\"status\":false,\"timestamp\":1637826588267}]";
-        
         List<URIRegisterDTO> list = new ArrayList<>();
         list.add(URIRegisterDTO.builder().appName("test1").rpcType(RpcTypeEnum.DUBBO.getName()).host(LOCALHOST).port(8090).build());
         SelectorDO selectorDO = mock(SelectorDO.class);
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDubboService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDubboService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
+        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
         List<DubboUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DubboUpstream.class);
         assertEquals(resultList.size(), 2);
 
@@ -179,5 +180,28 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
+    }
+
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split("}");
+        String out = "";
+        for (String str: splitStr) {
+            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
+            if (newStr.length() > 3) {
+                String[] small = newStr.split(",");
+                for (String str2:small) {
+                    if (str2.length() > 3) {
+                        list.add(str2);
+                    }                  
+                }
+            }
+            list.sort(Comparator.naturalOrder());
+            out += list.toString();
+            list.clear();
+            
+        }
+        return out;
+        
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
@@ -119,7 +119,7 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         assertEquals(orderdResult(expected), orderdResult(actual));
         List<GrpcUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, GrpcUpstream.class);
         assertEquals(resultList.size(), 2);
- 
+    
         //list.clear();
         list.add(URIRegisterDTO.builder().appName("test1").rpcType(RpcTypeEnum.GRPC.getName()).host("localhost").port(8092).build());
         selectorDO = mock(SelectorDO.class);
@@ -183,9 +183,9 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         for (String str: splitStr) {
             String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
             if (newStr.length() > 3) {
-                String[] small = str.split(",");
+                String[] small = newStr.split(",");
                 for (String str2:small) {
-                    if (str.length() > 3) {
+                    if (str2.length() > 3) {
                         list.add(str2);
                     }                  
                 }
@@ -198,5 +198,4 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         return out;
         
     }
-
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
@@ -42,6 +42,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -113,7 +114,8 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterTarsService).doSubmit(any(), any());
         String actual = shenyuClientRegisterTarsService.buildHandle(list, selectorDO);
-        assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
+        //assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
+        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
         List<TarsUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, TarsUpstream.class);
         assertEquals(resultList.size(), 2);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))
@@ -165,5 +167,28 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
+    }
+    
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split("}");
+        String out = "";
+        for (String str: splitStr) {
+            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
+            if (newStr.length() > 3) {
+                String[] small = newStr.split(",");
+                for (String str2:small) {
+                    if (str2.length() > 3) {
+                        list.add(str2);
+                    }                  
+                }
+            }
+            list.sort(Comparator.naturalOrder());
+            out += list.toString();
+            list.clear();
+            
+        }
+        return out;
+        
     }
 }


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
**Flaky test fix**

## What is the purpose of the change

The 
org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImplTest.testBuildHandle
org.apache.shenyu.admin.service.register.ShenyuClientRegisterDubboServiceImplTest.testBuildHandle
org.apache.shenyu.admin.service.register.ShenyuClientRegisterGrpcServiceImplTest.testBuildHandle
org.apache.shenyu.admin.service.register.ShenyuClientRegisterTarsServiceImplTest.testBuildHandle 
will failed at the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool as a flaky test.

In these tests the return value from the 'buildHandle' should be a string from a JSON format Object.(Mostly extend from CommonUpstream.java)

However, since the internal data of the `Object `is stored by `HashMap`, the order of `Bytes[]` generated by it will change every time it runs.

Like it will return` {"value":"value","key":"key"}` or `{"value":"value","key":"key"}` that coursed AssertError in  `testBuildHandle` which is a Flaky-test.

## Brief changelog

Add a method to sort the expect and actual String before checking them equally or not.
It should have some easier way to fix, but this way won't change any part of the Main code

## Verifying this change

This test will successfully pass the NonDex Test with these small changes.
I run the loca,l test and it passed except for some unapproved license error.
Since I didn't touch any Source code, it should be no impact on the project.


- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
