### PR TITLE
Fix flaky

### DIFF
--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -118,7 +118,7 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);
         assertEquals(resultList.size(), 3);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -40,11 +40,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -118,7 +118,8 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
         //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
-        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);
         assertEquals(resultList.size(), 3);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))
@@ -185,29 +186,5 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
-    }
-
-    private String orderdResult(final String result) {
-        ArrayList<String> list = new ArrayList<String>();
-        String[] splitStr = result.split("}");
-        String out = "";
-        for (String str: splitStr) {
-            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
-            if (newStr.length() > 3) {
-                String[] small = newStr.split(",");
-                for (String str2:small) {
-                    if (str2.length() > 3) {
-                        list.add(str2);
-                    }                  
-                }
-            }
-            list.sort(Comparator.naturalOrder());
-            out += list.toString();
-            list.clear();
-            
-        }
-        return out;
-        
-    }
-    
+    }   
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -118,7 +118,7 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
+        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);
         assertEquals(resultList.size(), 3);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -117,7 +117,6 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
-        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
         JsonParser parser = new JsonParser();
         assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -185,5 +185,5 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
-    }   
+    }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,7 +117,8 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);
         assertEquals(resultList.size(), 3);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))
@@ -184,4 +186,28 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
             throw new ShenyuException(e.getCause());
         }
     }
+
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split("}");
+        String out = "";
+        for (String str: splitStr) {
+            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
+            if (newStr.length() > 3) {
+                String[] small = newStr.split(",");
+                for (String str2:small) {
+                    if (str2.length() > 3) {
+                        list.add(str2);
+                    }                  
+                }
+            }
+            list.sort(Comparator.naturalOrder());
+            out += list.toString();
+            list.clear();
+            
+        }
+        return out;
+        
+    }
+    
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -117,7 +117,7 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         doReturn(false).when(shenyuClientRegisterDubboService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDubboService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         List<DubboUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DubboUpstream.class);
         assertEquals(resultList.size(), 2);
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -40,11 +40,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -109,14 +109,16 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         final String expected = "[{\"port\":0,\"weight\":50,\"warmup\":10,\"protocol\":\"dubbo://\",\"upstreamHost\":\"localhost\",\"upstreamUrl\":\"localhost:8090\","
                 + "\"status\":true,\"timestamp\":1637826588267},{\"port\":0,\"weight\":50,\"warmup\":10,\"protocol\":\"dubbo://\",\"upstreamHost\":\"localhost\","
                 + "\"upstreamUrl\":\"localhost:8091\",\"status\":false,\"timestamp\":1637826588267}]";
+        
         List<URIRegisterDTO> list = new ArrayList<>();
         list.add(URIRegisterDTO.builder().appName("test1").rpcType(RpcTypeEnum.DUBBO.getName()).host(LOCALHOST).port(8090).build());
         SelectorDO selectorDO = mock(SelectorDO.class);
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDubboService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDubboService.buildHandle(list, selectorDO);
-        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
         //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<DubboUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DubboUpstream.class);
         assertEquals(resultList.size(), 2);
 
@@ -180,28 +182,5 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
-    }
-
-    private String orderdResult(final String result) {
-        ArrayList<String> list = new ArrayList<String>();
-        String[] splitStr = result.split("}");
-        String out = "";
-        for (String str: splitStr) {
-            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
-            if (newStr.length() > 3) {
-                String[] small = newStr.split(",");
-                for (String str2:small) {
-                    if (str2.length() > 3) {
-                        list.add(str2);
-                    }                  
-                }
-            }
-            list.sort(Comparator.naturalOrder());
-            out += list.toString();
-            list.clear();
-            
-        }
-        return out;
-        
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -108,14 +109,14 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         final String expected = "[{\"port\":0,\"weight\":50,\"warmup\":10,\"protocol\":\"dubbo://\",\"upstreamHost\":\"localhost\",\"upstreamUrl\":\"localhost:8090\","
                 + "\"status\":true,\"timestamp\":1637826588267},{\"port\":0,\"weight\":50,\"warmup\":10,\"protocol\":\"dubbo://\",\"upstreamHost\":\"localhost\","
                 + "\"upstreamUrl\":\"localhost:8091\",\"status\":false,\"timestamp\":1637826588267}]";
-        
         List<URIRegisterDTO> list = new ArrayList<>();
         list.add(URIRegisterDTO.builder().appName("test1").rpcType(RpcTypeEnum.DUBBO.getName()).host(LOCALHOST).port(8090).build());
         SelectorDO selectorDO = mock(SelectorDO.class);
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDubboService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDubboService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
+        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
         List<DubboUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DubboUpstream.class);
         assertEquals(resultList.size(), 2);
 
@@ -179,5 +180,28 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
+    }
+
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split("}");
+        String out = "";
+        for (String str: splitStr) {
+            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
+            if (newStr.length() > 3) {
+                String[] small = newStr.split(",");
+                for (String str2:small) {
+                    if (str2.length() > 3) {
+                        list.add(str2);
+                    }                  
+                }
+            }
+            list.sort(Comparator.naturalOrder());
+            out += list.toString();
+            list.clear();
+            
+        }
+        return out;
+        
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -116,7 +116,6 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDubboService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDubboService.buildHandle(list, selectorDO);
-        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
         JsonParser parser = new JsonParser();
         assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<DubboUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DubboUpstream.class);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
@@ -40,11 +40,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -105,9 +105,9 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         
         final String returnStr = "[{upstreamUrl='localhost:8090',weight=1,status=true,timestamp=1637826588267},"
                 + "{upstreamUrl='localhost:8091',weight=2,status=true,timestamp=1637826588267}]";
-        final String expected = "[{\"weight\":1,\"status\":true,\"timestamp\":1637826588267,\"upstreamUrl\":\"localhost:8090\"},"
-                + "{\"weight\":2,\"status\":true,\"timestamp\":1637826588267,\"upstreamUrl\":\"localhost:8091\"}]";
-
+        final String expected = "[{\"weight\":1,\"upstreamUrl\":\"localhost:8090\",\"status\":true,\"timestamp\":1637826588267},"
+                + "{\"weight\":2,\"upstreamUrl\":\"localhost:8091\",\"status\":true,\"timestamp\":1637826588267}]";
+    
         List<URIRegisterDTO> list = new ArrayList<>();
         list.add(URIRegisterDTO.builder().appName("test1").rpcType(RpcTypeEnum.GRPC.getName()).host("localhost").port(8090).build());
         list.add(URIRegisterDTO.builder().appName("test2").rpcType(RpcTypeEnum.GRPC.getName()).host("localhost").port(8091).build());
@@ -115,8 +115,9 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterGrpcService).doSubmit(any(), any());
         String actual = shenyuClientRegisterGrpcService.buildHandle(list, selectorDO);
-        //assertEquals(expected, actual);
-        assertEquals(orderdResult(expected), orderdResult(actual));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(actual), parser.parse(expected));
+        //assertEquals(actual, expected);
         List<GrpcUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, GrpcUpstream.class);
         assertEquals(resultList.size(), 2);
     
@@ -176,26 +177,4 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         }
     }
 
-    private String orderdResult(final String result) {
-        ArrayList<String> list = new ArrayList<String>();
-        String[] splitStr = result.split("}");
-        String out = "";
-        for (String str: splitStr) {
-            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
-            if (newStr.length() > 3) {
-                String[] small = newStr.split(",");
-                for (String str2:small) {
-                    if (str2.length() > 3) {
-                        list.add(str2);
-                    }                  
-                }
-            }
-            list.sort(Comparator.naturalOrder());
-            out += list.toString();
-            list.clear();
-            
-        }
-        return out;
-        
-    }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
@@ -119,7 +119,7 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         assertEquals(orderdResult(expected), orderdResult(actual));
         List<GrpcUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, GrpcUpstream.class);
         assertEquals(resultList.size(), 2);
- 
+    
         //list.clear();
         list.add(URIRegisterDTO.builder().appName("test1").rpcType(RpcTypeEnum.GRPC.getName()).host("localhost").port(8092).build());
         selectorDO = mock(SelectorDO.class);
@@ -183,9 +183,9 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         for (String str: splitStr) {
             String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
             if (newStr.length() > 3) {
-                String[] small = str.split(",");
+                String[] small = newStr.split(",");
                 for (String str2:small) {
-                    if (str.length() > 3) {
+                    if (str2.length() > 3) {
                         list.add(str2);
                     }                  
                 }
@@ -198,5 +198,4 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         return out;
         
     }
-
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
@@ -116,7 +116,7 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         doReturn(false).when(shenyuClientRegisterGrpcService).doSubmit(any(), any());
         String actual = shenyuClientRegisterGrpcService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(actual), parser.parse(expected));
+        assertEquals(parser.parse(expected), parser.parse(actual));
         List<GrpcUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, GrpcUpstream.class);
         assertEquals(resultList.size(), 2);
     

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
@@ -117,7 +117,6 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         String actual = shenyuClientRegisterGrpcService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
         assertEquals(parser.parse(actual), parser.parse(expected));
-        //assertEquals(actual, expected);
         List<GrpcUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, GrpcUpstream.class);
         assertEquals(resultList.size(), 2);
     
@@ -176,5 +175,4 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
             throw new ShenyuException(e.getCause());
         }
     }
-
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -34,7 +34,8 @@ import org.mockito.quality.Strictness;
     
 import java.util.ArrayList;
 import java.util.List;
-    
+import java.util.Comparator;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -67,8 +68,10 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
     
     @Test
     public void testRuleHandler() {
-        assertEquals("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}",
-                shenyuClientRegisterSofaService.ruleHandler());
+        assertEquals(orderdResult("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}"),
+            orderdResult(shenyuClientRegisterSofaService.ruleHandler()));
+        //assertEquals("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}",
+                //shenyuClientRegisterSofaService.ruleHandler());
     }
     
     @Test
@@ -86,5 +89,20 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
         list.add(URIRegisterDTO.builder().build());
         assertEquals(StringUtils.EMPTY,
                 shenyuClientRegisterSofaService.buildHandle(list, SelectorDO.builder().build()));
+    }
+
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split(",");
+        String out = "";
+        for (String str2:splitStr) {
+            if (str2.length() > 3) {
+                list.add(str2.replaceAll("[\\}\\{\\[\\]]", ""));
+            }                  
+        }
+        list.sort(Comparator.naturalOrder());
+        out += list.toString();
+        list.clear();        
+        return out;       
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -71,8 +71,6 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
         String expected = "{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}";
         JsonParser parser = new JsonParser();
         assertEquals(parser.parse(shenyuClientRegisterSofaService.ruleHandler()), parser.parse(expected));
-        //assertEquals("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}",
-                //shenyuClientRegisterSofaService.ruleHandler());
     }
     
     @Test

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -32,7 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import com.google.gson.JsonParser;
-    
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -31,10 +31,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import com.google.gson.JsonParser;
     
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,8 +68,9 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
     
     @Test
     public void testRuleHandler() {
-        assertEquals(orderdResult("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}"),
-            orderdResult(shenyuClientRegisterSofaService.ruleHandler()));
+        String expected = "{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}";
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(shenyuClientRegisterSofaService.ruleHandler()), parser.parse(expected));
         //assertEquals("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}",
                 //shenyuClientRegisterSofaService.ruleHandler());
     }
@@ -89,20 +90,5 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
         list.add(URIRegisterDTO.builder().build());
         assertEquals(StringUtils.EMPTY,
                 shenyuClientRegisterSofaService.buildHandle(list, SelectorDO.builder().build()));
-    }
-
-    private String orderdResult(final String result) {
-        ArrayList<String> list = new ArrayList<String>();
-        String[] splitStr = result.split(",");
-        String out = "";
-        for (String str2:splitStr) {
-            if (str2.length() > 3) {
-                list.add(str2.replaceAll("[\\}\\{\\[\\]]", ""));
-            }                  
-        }
-        list.sort(Comparator.naturalOrder());
-        out += list.toString();
-        list.clear();        
-        return out;       
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -32,10 +32,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import com.google.gson.JsonParser;
-
+    
 import java.util.ArrayList;
 import java.util.List;
-
+    
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -68,9 +68,8 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
     
     @Test
     public void testRuleHandler() {
-        String expected = "{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}";
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(shenyuClientRegisterSofaService.ruleHandler()), parser.parse(expected));
+        assertEquals(parser.parse("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}"), parser.parse(shenyuClientRegisterSofaService.ruleHandler()));
     }
     
     @Test

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
@@ -118,7 +118,6 @@ public final class ShenyuClientRegisterSpringCloudServiceImplTest {
         doReturn(false).when(shenyuClientRegisterSpringCloudService).doSubmit(any(), any());
         when(selectorDO.getHandle()).thenReturn(returnStr);
         String actual = shenyuClientRegisterSpringCloudService.buildHandle(list, selectorDO);
-        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
         JsonParser parser = new JsonParser();
         assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         SpringCloudSelectorHandle handle = GsonUtils.getInstance().fromJson(actual, SpringCloudSelectorHandle.class);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +118,9 @@ public final class ShenyuClientRegisterSpringCloudServiceImplTest {
         doReturn(false).when(shenyuClientRegisterSpringCloudService).doSubmit(any(), any());
         when(selectorDO.getHandle()).thenReturn(returnStr);
         String actual = shenyuClientRegisterSpringCloudService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        //assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         SpringCloudSelectorHandle handle = GsonUtils.getInstance().fromJson(actual, SpringCloudSelectorHandle.class);
         assertEquals(handle.getDivideUpstreams().size(), 2);
         assertEquals(handle.getDivideUpstreams().stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
@@ -119,7 +119,7 @@ public final class ShenyuClientRegisterSpringCloudServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         String actual = shenyuClientRegisterSpringCloudService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         SpringCloudSelectorHandle handle = GsonUtils.getInstance().fromJson(actual, SpringCloudSelectorHandle.class);
         assertEquals(handle.getDivideUpstreams().size(), 2);
         assertEquals(handle.getDivideUpstreams().stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
@@ -114,7 +114,6 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterTarsService).doSubmit(any(), any());
         String actual = shenyuClientRegisterTarsService.buildHandle(list, selectorDO);
-        //assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
         JsonParser parser = new JsonParser();
         assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<TarsUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, TarsUpstream.class);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
@@ -42,6 +42,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -113,7 +114,8 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterTarsService).doSubmit(any(), any());
         String actual = shenyuClientRegisterTarsService.buildHandle(list, selectorDO);
-        assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
+        //assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
+        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
         List<TarsUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, TarsUpstream.class);
         assertEquals(resultList.size(), 2);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))
@@ -165,5 +167,28 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
+    }
+    
+    private String orderdResult(final String result) {
+        ArrayList<String> list = new ArrayList<String>();
+        String[] splitStr = result.split("}");
+        String out = "";
+        for (String str: splitStr) {
+            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
+            if (newStr.length() > 3) {
+                String[] small = newStr.split(",");
+                for (String str2:small) {
+                    if (str2.length() > 3) {
+                        list.add(str2);
+                    }                  
+                }
+            }
+            list.sort(Comparator.naturalOrder());
+            out += list.toString();
+            list.clear();
+            
+        }
+        return out;
+        
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
@@ -115,7 +115,7 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         doReturn(false).when(shenyuClientRegisterTarsService).doSubmit(any(), any());
         String actual = shenyuClientRegisterTarsService.buildHandle(list, selectorDO);
         JsonParser parser = new JsonParser();
-        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         List<TarsUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, TarsUpstream.class);
         assertEquals(resultList.size(), 2);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
@@ -38,11 +38,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -115,7 +115,8 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         doReturn(false).when(shenyuClientRegisterTarsService).doSubmit(any(), any());
         String actual = shenyuClientRegisterTarsService.buildHandle(list, selectorDO);
         //assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
-        assertEquals(orderdResult(expected.replaceAll("\\d{13}", "0")), orderdResult(actual.replaceAll("\\d{13}", "0")));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(actual.replaceAll("\\d{13}", "0")), parser.parse(expected.replaceAll("\\d{13}", "0")));
         List<TarsUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, TarsUpstream.class);
         assertEquals(resultList.size(), 2);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))
@@ -167,28 +168,5 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         } catch (Exception e) {
             throw new ShenyuException(e.getCause());
         }
-    }
-    
-    private String orderdResult(final String result) {
-        ArrayList<String> list = new ArrayList<String>();
-        String[] splitStr = result.split("}");
-        String out = "";
-        for (String str: splitStr) {
-            String newStr = str.replaceAll("[\\}\\{\\[\\]]", "");
-            if (newStr.length() > 3) {
-                String[] small = newStr.split(",");
-                for (String str2:small) {
-                    if (str2.length() > 3) {
-                        list.add(str2);
-                    }                  
-                }
-            }
-            list.sort(Comparator.naturalOrder());
-            out += list.toString();
-            list.clear();
-            
-        }
-        return out;
-        
     }
 }


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
**Flaky test fix**

## What is the purpose of the change

The 
org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImplTest.testBuildHandle
org.apache.shenyu.admin.service.register.ShenyuClientRegisterDubboServiceImplTest.testBuildHandle
org.apache.shenyu.admin.service.register.ShenyuClientRegisterGrpcServiceImplTest.testBuildHandle
org.apache.shenyu.admin.service.register.ShenyuClientRegisterTarsServiceImplTest.testBuildHandle 
org.apache.shenyu.admin.service.register.ShenyuClientRegisterSofaServiceImplTest.testRuleHandler
org.apache.shenyu.admin.service.register.ShenyuClientRegisterSpringCloudServiceImplTest
will failed at the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool as a flaky test.

In these tests the return value from the 'buildHandle' should be a string from a JSON format Object.(Mostly extend from CommonUpstream.java)

However, since the internal data of the `Object `is stored by `HashMap`, the order of `Bytes[]` generated by it will change every time it runs.

Like it will return` {"value":"value","key":"key"}` or `{"value":"value","key":"key"}` that coursed AssertError in  `testBuildHandle` which is a Flaky-test.

## Brief changelog

Since the JSON tool used in the Project is GSON, so I use GSON library `JsonParser `to convert the string back to json Object and compare them.
It will avoid nested or different order of Json string that coursed flaky error.

## Verifying this change

This test will successfully pass the NonDex Test with these small changes.
I run the local test, and it passed except for some unapproved license error.
Since I didn't touch any Source code, it should be no impact on the project.


- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
