### PR TITLE
Fixing flaky test

### DIFF
--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -116,7 +117,8 @@ public final class ShenyuClientRegisterDivideServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDivideService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDivideService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         List<DivideUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DivideUpstream.class);
         assertEquals(resultList.size(), 3);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -115,7 +116,8 @@ public final class ShenyuClientRegisterDubboServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterDubboService).doSubmit(any(), any());
         String actual = shenyuClientRegisterDubboService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         List<DubboUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, DubboUpstream.class);
         assertEquals(resultList.size(), 2);
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -114,7 +115,8 @@ public final class ShenyuClientRegisterGrpcServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterGrpcService).doSubmit(any(), any());
         String actual = shenyuClientRegisterGrpcService.buildHandle(list, selectorDO);
-        assertEquals(actual, expected);
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(expected), parser.parse(actual));
         List<GrpcUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, GrpcUpstream.class);
         assertEquals(resultList.size(), 2);
     

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSofaServiceImplTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import com.google.gson.JsonParser;
     
 import java.util.ArrayList;
 import java.util.List;
@@ -67,8 +68,8 @@ public final class ShenyuClientRegisterSofaServiceImplTest {
     
     @Test
     public void testRuleHandler() {
-        assertEquals("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}",
-                shenyuClientRegisterSofaService.ruleHandler());
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse("{\"retries\":0,\"loadBalance\":\"random\",\"timeout\":3000}"), parser.parse(shenyuClientRegisterSofaService.ruleHandler()));
     }
     
     @Test

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +118,8 @@ public final class ShenyuClientRegisterSpringCloudServiceImplTest {
         doReturn(false).when(shenyuClientRegisterSpringCloudService).doSubmit(any(), any());
         when(selectorDO.getHandle()).thenReturn(returnStr);
         String actual = shenyuClientRegisterSpringCloudService.buildHandle(list, selectorDO);
-        assertEquals(expected.replaceAll("\\d{13}", "0"), actual.replaceAll("\\d{13}", "0"));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         SpringCloudSelectorHandle handle = GsonUtils.getInstance().fromJson(actual, SpringCloudSelectorHandle.class);
         assertEquals(handle.getDivideUpstreams().size(), 2);
         assertEquals(handle.getDivideUpstreams().stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.google.gson.JsonParser;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -113,7 +114,8 @@ public final class ShenyuClientRegisterTarsServiceImplTest {
         when(selectorDO.getHandle()).thenReturn(returnStr);
         doReturn(false).when(shenyuClientRegisterTarsService).doSubmit(any(), any());
         String actual = shenyuClientRegisterTarsService.buildHandle(list, selectorDO);
-        assertEquals(actual.replaceAll("\\d{13}", "0"), expected.replaceAll("\\d{13}", "0"));
+        JsonParser parser = new JsonParser();
+        assertEquals(parser.parse(expected.replaceAll("\\d{13}", "0")), parser.parse(actual.replaceAll("\\d{13}", "0")));
         List<TarsUpstream> resultList = GsonUtils.getInstance().fromCurrentList(actual, TarsUpstream.class);
         assertEquals(resultList.size(), 2);
         assertEquals(resultList.stream().filter(r -> list.stream().map(dto -> CommonUpstreamUtils.buildUrl(dto.getHost(), dto.getPort()))


### PR DESCRIPTION
## **Flaky test fix**
- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

<!-- Describe your PR here; eg. Fixes #issueNo -->
## What is the purpose of the change
The `org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImplTest.testBuildHandle` has flakiness.

The test flakiness is due to comparisons between Json Strings and outputs from` JsonUtils.toJson()` and `GsonUtils.getInstance().toJson()`. 
However, JsonObject does not guarantee entry orders, its object is an unordered set of name/value pairs, and internal permutations may occur in the output from toJson().

There are five more similar tests that also have these kinds of flakiness. This is just an example, I will change the other five if you accept these changes.
## Brief changelog

Since the JSON tool used in the Project is GSON, so I use the GSON library `JsonParser `to convert the string back to JSON Object and compare them.  

## Verifying this change

This test avoids nested or different orders of JSON strings that cause flaky errors.
Since I didn't touch any Source code, it should be no impact on the project.
And it passed the local test that the guidelines mentioned.



